### PR TITLE
Allow usage of "/" as LH_HEALTHCHECK_PATH

### DIFF
--- a/health.go
+++ b/health.go
@@ -10,10 +10,11 @@ import (
 )
 
 func waitForHealthy(ctx context.Context, port string) {
-	path := strings.TrimPrefix(os.Getenv("LH_HEALTHCHECK_PATH"), "/")
+	path := os.Getenv("LH_HEALTHCHECK_PATH")
 	if path == "" {
-		path = "ping"
+		path = "/ping"
 	}
+	path = strings.TrimPrefix(path, "/")
 
 	url := fmt.Sprintf("http://127.0.0.1:%s/%s", port, path)
 


### PR DESCRIPTION
Presently if you try to set `LH_HEALTHCHECK_PATH` to just `/` it will be trimmed and then compared to an empty string and reset to `ping`.

This moves the comparison before the trimming to differentiate between the default empty string and `/`.